### PR TITLE
Bugfix: Incorrect 'lib' dir on CentOS

### DIFF
--- a/esy-build.sh
+++ b/esy-build.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
-cmake -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$cur__install -S $cur__root -B $cur__target_dir
+cmake -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$cur__install -DCMAKE_INSTALL_DEFAULT_LIBDIR=lib -S $cur__root -B $cur__target_dir
 make -C $cur__target_dir
 make -C $cur__target_dir install


### PR DESCRIPTION
__Issue:__ When building on CentOS 7, `-ljpeg` could not be found.

__Defect:__ The libraries were being put in `$prefix/lib64` instead of `$prefix/lib`

__Fix:__ Specify lib directory